### PR TITLE
New Prada2013 LFP dataset

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,2 @@
 {
-    "julia.environmentPath": "c:\\Users\\dslaifstein\\Documents\\GitHub\\LiiBRA"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "c:\\Users\\dslaifstein\\Documents\\GitHub\\LiiBRA"
+}

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ UnitSystems = "3a241a3c-2137-41aa-af5e-1388e404ca09"
 
 [compat]
 FFTW = "1.4"
-Interpolations = "0.16.2"
-JLD2 = "0.6.3"
+JLD2 = "0.4, 0.5, 0.6"
+Interpolations = "0.13, 0.14, 0.15, 0.16"
 Parameters = "0.12"
 Roots = "1.3, 2"
 Statistics = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LiiBRA"
 uuid = "a5b28938-1935-4481-b801-30e5c8ed4e83"
-authors = ["Brady Planden <info@bradyplanden.com>"]
 version = "0.3.4"
+authors = ["Brady Planden <info@bradyplanden.com>"]
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -17,8 +17,8 @@ UnitSystems = "3a241a3c-2137-41aa-af5e-1388e404ca09"
 
 [compat]
 FFTW = "1.4"
-Interpolations = "0.13, 0.14, 0.15"
-JLD2 = "0.4"
+Interpolations = "0.16.2"
+JLD2 = "0.6.3"
 Parameters = "0.12"
 Roots = "1.3, 2"
 Statistics = "1"

--- a/examples/WLTP.jl
+++ b/examples/WLTP.jl
@@ -1,3 +1,4 @@
+cd(@__DIR__)
 using LiiBRA, MAT, Plots
 plotly()
 default(show = true)
@@ -6,10 +7,11 @@ default(show = true)
 Sₑ = 4 # Spatial points in electrolyte
 Sₛ = 4 # Spatial point in solid
 Cell = Construct("LG M50")
+# Cell = Construct("A123")
 Spatial!(Cell, Sₑ, Sₛ)
 Ŝ = collect(1.0:-1:0.0)
 SOC = 0.717
-WLTP_File = matopen("examples/WLTP/WLTP_M50_M3.mat")
+WLTP_File = matopen("../examples/WLTP/WLTP_M50_M3.mat")
 WLTP_P = read(WLTP_File, "P_Models")
 
 #---------- Generate & Simulate Model -----------------#

--- a/src/Data/Chen_2020/LG_M50.jl
+++ b/src/Data/Chen_2020/LG_M50.jl
@@ -274,6 +274,6 @@ end
     RA::Realisation
     Transfer::TransferFun
 end
-
+export Constants, Negative, Positive, Separator, Realisation, TransferFun, Params
 return Params(Constants(), Negative(), Positive(), Separator(), Realisation(),
               TransferFun())

--- a/src/Data/Chen_2020/LG_M50.jl
+++ b/src/Data/Chen_2020/LG_M50.jl
@@ -274,6 +274,5 @@ end
     RA::Realisation
     Transfer::TransferFun
 end
-export Constants, Negative, Positive, Separator, Realisation, TransferFun, Params
 return Params(Constants(), Negative(), Positive(), Separator(), Realisation(),
               TransferFun())

--- a/src/Data/Doyle_94/Doyle_94.jl
+++ b/src/Data/Doyle_94/Doyle_94.jl
@@ -131,4 +131,3 @@ CellData.Const.D1 = CellData.Const.De*CellData.Neg.ϵ_e^CellData.Neg.De_brug
 CellData.Const.D2 = CellData.Const.De*CellData.Sep.ϵ_e^CellData.Sep.De_brug
 CellData.Const.D3 = CellData.Const.De*CellData.Pos.ϵ_e^CellData.Pos.De_brug
 CellData.Const.Ce_M = size(CellData.Transfer.tfs[1,3],1)
-export Constants, Negative, Positive, Seperator, RealisationAlgorthim, TransferFun, Cell

--- a/src/Data/Doyle_94/Doyle_94.jl
+++ b/src/Data/Doyle_94/Doyle_94.jl
@@ -131,3 +131,4 @@ CellData.Const.D1 = CellData.Const.De*CellData.Neg.ϵ_e^CellData.Neg.De_brug
 CellData.Const.D2 = CellData.Const.De*CellData.Sep.ϵ_e^CellData.Sep.De_brug
 CellData.Const.D3 = CellData.Const.De*CellData.Pos.ϵ_e^CellData.Pos.De_brug
 CellData.Const.Ce_M = size(CellData.Transfer.tfs[1,3],1)
+export Constants, Negative, Positive, Seperator, RealisationAlgorthim, TransferFun, Cell

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -16,26 +16,30 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     SOC::Float64 = 1.0                                                          # Initial State of Charge
     ce0::Float64 = 1200                                                         # Initial Electrolyte Concentration (mol m⁻³)
     Vmin::Float64 = 2.0                                                         # Min Cell Voltage
-    Ea_κ::Float64 = 0.0 # check
+    Ea_κ::Float64 = 0.0 # check 
     Ea_De::Float64 = 0 # check
-    CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area 
-    κ::Float64 = 0.9487 # check
-    κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
-                         3.329 * (ce / 1000) # check
+    CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area (m²)                                           
+    κ::Float64 = 0.9487                                                         # Electrolyte Conductivity
+    # κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
+    #                      3.329 * (ce / 1000) 
+    κf::Function = ce -> (4.1253e-4 + 5.007 * (ce / 1e6) -
+                          4721.2 * (ce / 1e6)^2 +
+                          1.5094e6 * (ce / 1e6)^3 -
+                          1.6018e8 * (ce / 1e6)^4) * 1e3     # Electrolyte Conductivity Function(S/m)
     Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
                   0.0909 * tanh(29.8538 * (θ - 0.1234)) -
                   0.04478 * tanh(14.9159 * (θ - 0.2769)) -
                   0.0205 * tanh(30.4444 * (θ - 0.6103))
     else
-        Uocp = @. 3.4077 - 0.020269 * θ + 0.5 * ℯ^(-150*θ) - 0.9 * ℯ^(-30*(1-θ))
+        Uocp = @. 3.4077 - 0.020269 * θ + 0.5 * exp(-150*θ) - 0.9 * exp(-30*(1-θ))
     end
     ∂Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         ∂Uocp = @. -0.62411 * ((sech(18.5802 - 30.4444 * θ))^2 +
                     4.34813 * (sech(3.68396 - 29.8538 * θ))^2 +
                     1.07022 * (sech(4.13021 - 14.9159 * θ))^2) - 211.794 * exp(-39.3631 * θ)
     else
-        ∂Uocp = @. - 0.020269 - 75 * ℯ^(-150 * θ) - 2.52656e-12 * ℯ^(30 * θ)
+        ∂Uocp = @. - 0.020269 - 75 * exp(-150 * θ) - 2.52656e-12 * exp(30 * θ)
     end
     Ce_M::Int64 = 1                             # Over-written
     D1::Float64 = 1.0
@@ -60,13 +64,8 @@ end
     κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
     σ::Float64 = 215                            # Solid Phase Conductivity
     σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
-<<<<<<< HEAD
     θ_100::Float64 = 0.8100363695199028         # Theta @ 100% Lithium Concentration
     θ_0::Float64 = 0.017619411644243348         # Theta @ 0% Lithium Concentration
-=======
-    θ_100::Float64 = 0.8100363695199028         # Theta @ 100% Lithium Concentration CHECK
-    θ_0::Float64 = 0.017619411644243348         # Theta @ 0% Lithium Concentration CHECK
->>>>>>> origin/Prada2013
     cs_max::Float64 = 30555                     # Max Electrode Concentration
     α::Float64 = 0.5                            # Alpha Factor
     k_norm::Float64 = 6.716047e-12              # check Reaction Rate
@@ -92,13 +91,8 @@ end
     κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
     σ::Float64 = 0.33795074                     # Solid Phase Conductivity
     σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
-<<<<<<< HEAD
     θ_100::Float64 = 0.003767884398705004       # Theta @ 100% Lithium Concentration
     θ_0::Float64 = 0.703500714165226            # Theta @ 0% Lithium Concentration
-=======
-    θ_100::Float64 = 0.003767884398705004       # Theta @ 100% Lithium Concentration CHECK
-    θ_0::Float64 = 0.703500714165226            # Theta @ 0% Lithium Concentration CHECK
->>>>>>> origin/Prada2013
     cs_max::Float64 = 22806                     # Max Electrode Concentration
     α::Float64 = 0.5                            # Alpha Factor
     k_norm::Float64 = 3.54458e-11               # check Reaction Rate CHECK

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -16,7 +16,7 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     SOC::Float64 = 1.0                                                          # Initial State of Charge
     ce0::Float64 = 1200                                                         # Initial Electrolyte Concentration (mol m⁻³)
     Vmin::Float64 = 2.0                                                         # Min Cell Voltage
-    Ea_κ::Float64 = 0.0 # check
+    Ea_κ::Float64 = 0.0 # check 
     Ea_De::Float64 = 0 # check
     CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area (m²)                                           
     # κ::Float64 = 0.9487 # Electrolyte Conductivity
@@ -26,21 +26,21 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     κf::Function = ce -> (4.1253e-4 + 5.007 * (ce / 1e6) -
                           4721.2 * (ce / 1e6)^2 +
                           1.5094e6 * (ce / 1e6)^3 -
-                          1.6018e8 * (ce / 1e6)^4)*1e3     # Electrolyte Conductivity Function(S/m)
+                          1.6018e8 * (ce / 1e6)^4) * 1e3     # Electrolyte Conductivity Function(S/m)
     Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
                   0.0909 * tanh(29.8538 * (θ - 0.1234)) -
                   0.04478 * tanh(14.9159 * (θ - 0.2769)) -
                   0.0205 * tanh(30.4444 * (θ - 0.6103))
     else
-        Uocp = @. 3.4077 - 0.020269 * θ + 0.5 * ℯ^(-150*θ) - 0.9 * ℯ^(-30*(1-θ))
+        Uocp = @. 3.4077 - 0.020269 * θ + 0.5 * exp(-150*θ) - 0.9 * exp(-30*(1-θ))
     end
     ∂Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         ∂Uocp = @. -0.62411 * ((sech(18.5802 - 30.4444 * θ))^2 +
                     4.34813 * (sech(3.68396 - 29.8538 * θ))^2 +
                     1.07022 * (sech(4.13021 - 14.9159 * θ))^2) - 211.794 * exp(-39.3631 * θ)
     else
-        ∂Uocp = @. - 0.020269 - 75 * ℯ^(-150 * θ) - 2.52656e-12 * ℯ^(30 * θ)
+        ∂Uocp = @. - 0.020269 - 75 * exp(-150 * θ) - 2.52656e-12 * exp(30 * θ)
     end
     Ce_M::Int64 = 1                             # Over-written
     D1::Float64 = 1.0

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -8,7 +8,7 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     T::Float64 = 298.15                                                         # Cell Temperature (K)
     T_ref::Float64 = 298.15                                                     # Reference Temperature (K)
     t_plus::Float64 = 0.36                                                      # Inital Transference Number
-    tpf::Function = ce -> -0.1287 * (ce / 1000)^3 + 0.4106 * (ce / 1000)^2 -
+    tpf::Function = ce -> -0.1287 * (ce / 1000)^3 + 0.4106 * (ce / 1000)^2 
                           0.4717 * (ce / 1000) + 0.4492                         # Transference Number Function 
     De::Float64 = 2.0e-10                                                       # Inital Electrolyte Diffusivity (J mol⁻¹)
     Def::Function = ce -> 8.794e-11 * (ce / 1000)^2 - 3.972e-10 *
@@ -18,10 +18,13 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     Vmin::Float64 = 2.0                                                         # Min Cell Voltage
     Ea_κ::Float64 = 0.0 # check
     Ea_De::Float64 = 0 # check
-    CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area 
-    κ::Float64 = 0.9487 # check
-    κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
-                         3.329 * (ce / 1000) # check
+    CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area (m²)                                           
+    # κ::Float64 = 0.9487 # Electrolyte Conductivity
+    # κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
+    #                      3.329 * (ce / 1000) 
+    κ::Float64 = 0.9487                                                         # Electrolyte Conductivity
+    κf::Function = ce -> (4.1253e-4 + 5.007 * ce/1e6 - 4721.2 * (ce/1e6)^2 +
+                         1.5094e6 * (ce/1e6)^3 - 1.6018e8 * (ce/1e6)^4)*1e3     # Electrolyte Conductivity Function(S/m)
     Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
                   0.0909 * tanh(29.8538 * (θ - 0.1234)) -
@@ -60,12 +63,12 @@ end
     κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
     σ::Float64 = 215                            # Solid Phase Conductivity
     σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
-    θ_100::Float64 = 0.910612                   # Theta @ 100% Lithium Concentration CHECK
-    θ_0::Float64 = 0.0263473                    # Theta @ 0% Lithium Concentration CHECK
+    θ_100::Float64 = 0.8100363695199028         # Theta @ 100% Lithium Concentration CHECK
+    θ_0::Float64 = 0.017619411644243348         # Theta @ 0% Lithium Concentration CHECK
     cs_max::Float64 = 30555                     # Max Electrode Concentration
     α::Float64 = 0.5                            # Alpha Factor
-    k_norm::Float64 = 6.716047e-12              # Reaction Rate
-    Ea_κ::Float64 = 35000                       # Activation Energy
+    k_norm::Float64 = 6.716047e-12              # check Reaction Rate
+    Ea_κ::Float64 = 35000                       # check Activation Energy
     RFilm::Float64 = 0                          # Film Resistance - Ωm²
     D1::Float64 = 1.0                           # Init Value
     D1f::Function = De -> De * ϵ_e^De_brug      # Effective Diffusivity
@@ -87,12 +90,12 @@ end
     κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
     σ::Float64 = 0.33795074                     # Solid Phase Conductivity
     σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
-    θ_100::Float64 = 0.263849                   # Theta @ 100% Lithium Concentration CHECK
-    θ_0::Float64 = 0.853974                     # Theta @ 0% Lithium Concentration CHECK
+    θ_100::Float64 = 0.003767884398705004       # Theta @ 100% Lithium Concentration CHECK
+    θ_0::Float64 = 0.703500714165226            # Theta @ 0% Lithium Concentration CHECK
     cs_max::Float64 = 22806                     # Max Electrode Concentration
     α::Float64 = 0.5                            # Alpha Factor
-    k_norm::Float64 = 3.54458e-11               # Reaction Rate CHECK
-    Ea_κ::Float64 = 17800                       # Activation Energy CHECK
+    k_norm::Float64 = 3.54458e-11               # check Reaction Rate CHECK
+    Ea_κ::Float64 = 17800                       # check Activation Energy CHECK
     RFilm::Float64 = 0                          # Film Resistance - Ωm²
     D3::Float64 = 1                             # Init Value CHECK
     D3f::Function = De -> De * ϵ_e^De_brug      # Effective Diffusivity

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -20,13 +20,13 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     Ea_De::Float64 = 0 # check
     CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area (m²)                                           
     # κ::Float64 = 0.9487 # Electrolyte Conductivity
-    # κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
-    #                      3.329 * (ce / 1000) 
+    κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
+                         3.329 * (ce / 1000) 
     κ::Float64 = 0.9487                                                         # Electrolyte Conductivity
-    κf::Function = ce -> (4.1253e-4 + 5.007 * (ce / 1e6) -
-                          4721.2 * (ce / 1e6)^2 +
-                          1.5094e6 * (ce / 1e6)^3 -
-                          1.6018e8 * (ce / 1e6)^4) * 1e3     # Electrolyte Conductivity Function(S/m)
+    # κf::Function = ce -> (4.1253e-4 + 5.007 * (ce / 1e6) -
+    #                       4721.2 * (ce / 1e6)^2 +
+    #                       1.5094e6 * (ce / 1e6)^3 -
+    #                       1.6018e8 * (ce / 1e6)^4) * 1e3     # Electrolyte Conductivity Function(S/m)
     Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
                   0.0909 * tanh(29.8538 * (θ - 0.1234)) -

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -23,8 +23,8 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     # κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
     #                      3.329 * (ce / 1000) 
     κ::Float64 = 0.9487                                                         # Electrolyte Conductivity
-    κf::Function = ce -> (4.1253e-4 + 5.007 * ce/1e6 - 4721.2 * (ce/1e6)^2 +
-                         1.5094e6 * (ce/1e6)^3 - 1.6018e8 * (ce/1e6)^4)*1e3     # Electrolyte Conductivity Function(S/m)
+    κf::Function = ce -> (4.1253e-4 + 5.007 * ce /1e6 - 4721.2 * (ce /1e6)^2 +
+                         1.5094e6 * (ce /1e6)^3 - 1.6018e8 * (ce /1e6)^4)*1e3     # Electrolyte Conductivity Function(S/m)
     Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
                   0.0909 * tanh(29.8538 * (θ - 0.1234)) -

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -60,8 +60,8 @@ end
     κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
     σ::Float64 = 215                            # Solid Phase Conductivity
     σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
-    θ_100::Float64 = 0.910612                   # Theta @ 100% Lithium Concentration CHECK
-    θ_0::Float64 = 0.0263473                    # Theta @ 0% Lithium Concentration CHECK
+    θ_100::Float64 = 0.8100363695199028         # Theta @ 100% Lithium Concentration
+    θ_0::Float64 = 0.017619411644243348         # Theta @ 0% Lithium Concentration
     cs_max::Float64 = 30555                     # Max Electrode Concentration
     α::Float64 = 0.5                            # Alpha Factor
     k_norm::Float64 = 6.716047e-12              # Reaction Rate
@@ -87,8 +87,8 @@ end
     κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
     σ::Float64 = 0.33795074                     # Solid Phase Conductivity
     σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
-    θ_100::Float64 = 0.263849                   # Theta @ 100% Lithium Concentration CHECK
-    θ_0::Float64 = 0.853974                     # Theta @ 0% Lithium Concentration CHECK
+    θ_100::Float64 = 0.003767884398705004       # Theta @ 100% Lithium Concentration
+    θ_0::Float64 = 0.703500714165226            # Theta @ 0% Lithium Concentration
     cs_max::Float64 = 22806                     # Max Electrode Concentration
     α::Float64 = 0.5                            # Alpha Factor
     k_norm::Float64 = 3.54458e-11               # Reaction Rate CHECK

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -1,0 +1,280 @@
+using Parameters
+"""
+Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
+"""
+
+@with_kw mutable struct Constants
+    CellTyp::String = "A123"                                                    # LFP, Prada (2013) A123 Systems ANR26650 m1
+    T::Float64 = 298.15                                                         # Cell Temperature (K)
+    T_ref::Float64 = 298.15                                                     # Reference Temperature (K)
+    t_plus::Float64 = 0.36                                                      # Inital Transference Number
+    tpf::Function = ce -> -0.1287 * (ce / 1000)^3 + 0.4106 * (ce / 1000)^2 -
+                          0.4717 * (ce / 1000) + 0.4492                         # Transference Number Function 
+    De::Float64 = 2.0e-10                                                       # Inital Electrolyte Diffusivity (J mol⁻¹)
+    Def::Function = ce -> 8.794e-11 * (ce / 1000)^2 - 3.972e-10 *
+                                                      (ce / 1000) + 4.862e-10   # CHECK Electrolyte Diffusivity Function 
+    SOC::Float64 = 1.0                                                          # Initial State of Charge
+    ce0::Float64 = 1200                                                         # Initial Electrolyte Concentration (mol m⁻³)
+    Vmin::Float64 = 2.0                                                         # Min Cell Voltage
+    Ea_κ::Float64 = 0.0 # check
+    Ea_De::Float64 = 0 # check
+    CC_A::Float64 = 0.6*0.3                                                     # Electrode Plate Area 
+    κ::Float64 = 0.9487 # check
+    κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
+                         3.329 * (ce / 1000) # check
+    Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
+        Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
+                  0.0909 * tanh(29.8538 * (θ - 0.1234)) -
+                  0.04478 * tanh(14.9159 * (θ - 0.2769)) -
+                  0.0205 * tanh(30.4444 * (θ - 0.6103))
+    else
+        Uocp = @. 3.4077 - 0.020269 * θ + 0.5 * ℯ^(-150*θ) - 0.9 * ℯ^(-30*(1-θ))
+    end
+    ∂Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
+        ∂Uocp = @. -0.62411 * ((sech(18.5802 - 30.4444 * θ))^2 +
+                    4.34813 * (sech(3.68396 - 29.8538 * θ))^2 +
+                    1.07022 * (sech(4.13021 - 14.9159 * θ))^2) - 211.794 * exp(-39.3631 * θ)
+    else
+        ∂Uocp = @. - 0.020269 - 75 * ℯ^(-150 * θ) - 2.52656e-12 * ℯ^(30 * θ)
+    end
+    Ce_M::Int64 = 1                             # Over-written
+    D1::Float64 = 1.0
+    D2::Float64 = 1.0
+    D3::Float64 = 1.0
+    Ltot::Float64 = 0.0
+    Lnegsep::Float64 = 0.0
+    CeRootRange::Float64 = 20
+    Debug::Bool = false
+end
+
+# CHECK
+@with_kw mutable struct Negative
+    L::Float64 = 3.4e-5                         # Negative Electrode Length
+    Rs::Float64 = 5e-6                          # Particle Radius [m]
+    Ds::Float64 = 3e-15                         # Solid Diffusivity [m^2/s]
+    Ea_σ::Float64 = 0                           # Activation Energy Solid Conductivity
+    Ea_Ds::Float64 = 0                          # Activation Energy Solid Diffusivity
+    ϵ_s::Float64 = 0.58                         # Active Material Volume Fraction
+    ϵ_e::Float64 = 0.36                         # Porosity of Negative Electrode
+    De_brug::Float64 = 1.5                      # Bruggeman Diffusion Exponent
+    κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
+    σ::Float64 = 215                            # Solid Phase Conductivity
+    σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
+    θ_100::Float64 = 0.910612                   # Theta @ 100% Lithium Concentration CHECK
+    θ_0::Float64 = 0.0263473                    # Theta @ 0% Lithium Concentration CHECK
+    cs_max::Float64 = 30555                     # Max Electrode Concentration
+    α::Float64 = 0.5                            # Alpha Factor
+    k_norm::Float64 = 6.716047e-12              # Reaction Rate
+    Ea_κ::Float64 = 35000                       # Activation Energy
+    RFilm::Float64 = 0                          # Film Resistance - Ωm²
+    D1::Float64 = 1.0                           # Init Value
+    D1f::Function = De -> De * ϵ_e^De_brug      # Effective Diffusivity
+    as::Float64 = 3.0 * ϵ_s / Rs                # Specific Interfacial Surf. Area
+    β::Array{ComplexF64} = [0 - 0.0im]          # Init Value
+    β!::Function = (s) -> @. Rs * sqrt(s / Ds)  # Negative β
+
+end
+
+@with_kw mutable struct Positive
+    L::Float64 = 8e-5                           # Positive Electrode Length
+    Rs::Float64 = 5e-08                         # Particle radius [m]
+    Ds::Float64 = 5.9e-18                       # Solid diffusivity [m^2/s]
+    Ea_σ::Float64 = 0                           # Activation Energy Solid Conductivity CHECK
+    Ea_Ds::Float64 = 0                          # Activation Energy Solid Diffusivity CHECK
+    ϵ_s::Float64 = 0.374                        # Active Material Volume Fraction
+    ϵ_e::Float64 = 0.426                        # Porosity of positive electrode
+    De_brug::Float64 = 1.5                      # Bruggeman Diffusivity Exponent
+    κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Exponent
+    σ::Float64 = 0.33795074                     # Solid Phase Conductivity
+    σ_brug::Float64 = 1.5                       # Bruggeman Solid Conductivity Exponent
+    θ_100::Float64 = 0.263849                   # Theta @ 100% Lithium Concentration CHECK
+    θ_0::Float64 = 0.853974                     # Theta @ 0% Lithium Concentration CHECK
+    cs_max::Float64 = 22806                     # Max Electrode Concentration
+    α::Float64 = 0.5                            # Alpha Factor
+    k_norm::Float64 = 3.54458e-11               # Reaction Rate CHECK
+    Ea_κ::Float64 = 17800                       # Activation Energy CHECK
+    RFilm::Float64 = 0                          # Film Resistance - Ωm²
+    D3::Float64 = 1                             # Init Value CHECK
+    D3f::Function = De -> De * ϵ_e^De_brug      # Effective Diffusivity
+    as::Float64 = 3.0 * ϵ_s / Rs                # Specific interfacial surf. area
+    β::Array{ComplexF64} = [0 - 0.0im]          # Init Value
+    β!::Function = (s) -> @. Rs * sqrt(s / Ds)  # Positive β
+end
+
+@with_kw mutable struct Separator
+    L::Float64 = 2.5e-5                         # Separator Length
+    ϵ_e::Float64 = 0.45                         # Porosity of separator
+    De_brug::Float64 = 1.5                      # Bruggeman Diffusivity Factor
+    κ_brug::Float64 = 1.5                       # Bruggeman Electrolyte Conductivity Factor
+    D2::Float64 = 1                             # Init Value
+    D2f::Function = De -> De * ϵ_e^De_brug      # Effective Diffusivity
+end
+
+@with_kw mutable struct Realisation
+    Fs::Float64 = 1                             # Sampling Frequency of Transfer Functions [Hz]
+    SamplingT::Float64 = 1                      # Final Model Sampling Time [s]
+    M::Int64 = 4                                # Model Order
+    N::Int64 = 1                                # Number of Inputs
+    Tlen::Int64 = 16200                         # Transfer Function Response Length [s]
+    H1::Array{Int64, 1} = [1:2500; 3000:3500]   # Hankel Dimensions 1
+    H2::Array{Int64, 1} = [1:2500; 3000:3500]   # Hankel Dimensions 2
+    Outs::Int64 = 1                             # Number of Outputs (Rewritten)
+    Nfft::Int64 = 0
+    f::UnitRange{Int64} = 0:1
+    s::Array{ComplexF64} = [0 - 0.0im]
+    Nfft!::Function = (Fs, Tlen) -> ceil(2^(log2(Fs * Tlen)))
+    f!::Function = (Nfft) -> 0:(Nfft - 1)
+    s!::Function = (Fs, Nfft, f) -> transpose(((2im .* Fs) * tan.(pi .* f ./ Nfft)))
+end
+
+@with_kw mutable struct TransferFun
+    # Number of Spatial Points in Electrolyte and Solid
+    Sₑ::Int = 4
+    Sₛ::Int = 2
+
+    tfs::Vector{Function} = [
+        C_e,
+        Phi_e,
+        C_se,
+        Phi_s,
+        Phi_se,
+        Flux,
+        C_se,
+        Phi_s,
+        Flux,
+        Phi_se,
+    ]
+
+    Elec::Vector{String} = [
+        "Na",
+        "Na",
+        "Pos",
+        "Pos",
+        "Pos",
+        "Pos",
+        "Neg",
+        "Neg",
+        "Neg",
+        "Neg",
+    ]
+
+    Locs::Function = (Sₑ, Sₛ) -> if Sₑ == 6 && Sₛ == 4
+        return [
+            Float64[0, 4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+        ]
+    elseif Sₑ == 4 && Sₛ == 4
+        return [
+            Float64[0.0, 8.52e-5, 9.72e-5, 1.728e-4],
+            Float64[8.52e-5, 9.72e-5, 1.728e-4],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+        ]
+    elseif Sₑ == 8 && Sₛ == 4
+        return [
+            Float64[0, 2.84e-5, 5.68e-5, 8.52e-5, 9.72e-5, 1.224e-4, 1.476e-4, 1.728e-4],
+            Float64[2.84e-5, 5.68e-5, 8.52e-5, 9.72e-5, 1.224e-4, 1.476e-4, 1.728e-4],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+        ]
+    elseif Sₑ == 9 && Sₛ == 6
+        return [
+            Float64[0, 2.84e-5, 5.68e-5, 8.52e-5, 9.12e-5, 9.72e-5, 0.0001224, 0.0001476,
+                    1.728e-4],
+            Float64[2.84e-5, 5.68e-5, 8.52e-5, 9.12e-5, 9.72e-5, 0.0001224, 0.0001476,
+                    1.728e-4],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+            Float64[0, 1 / 3, 2 / 3, 1],
+        ]
+    elseif Sₑ == 4 && Sₛ == 2
+        [
+            Float64[0, 8.52E-05, 9.72E-05, 1.728E-04],
+            Float64[8.52E-05, 9.72E-05, 1.728E-04],
+            Float64[0, 1],
+            Float64[1],
+            Float64[0, 1],
+            Float64[0, 1],
+            Float64[0, 1],
+            Float64[1],
+            Float64[0, 1],
+            Float64[0, 1],
+        ]
+    elseif Sₑ == 4 && Sₛ == 6
+        return [
+            Float64[0.00, 4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+        ]
+    elseif Sₑ == 6 && Sₛ == 2
+        return [
+            Float64[0, 4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[0, 1],
+            Float64[1],
+            Float64[0, 1],
+            Float64[0, 1],
+            Float64[0, 1],
+            Float64[1],
+            Float64[0, 1],
+            Float64[0, 1],
+        ]
+    elseif Sₑ == 6 && Sₛ == 6
+        return [
+            Float64[0.00, 4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[4.26e-5, 8.52e-5, 9.72e-5, 1.35e-04, 1.728e-4],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+            Float64[0, 0.2, 0.4, 0.6, 0.8, 1],
+        ]
+    end
+end
+
+@with_kw mutable struct Params
+    Const::Constants
+    Neg::Negative
+    Pos::Positive
+    Sep::Separator
+    RA::Realisation
+    Transfer::TransferFun
+end
+
+return Params(Constants(), Negative(), Positive(), Separator(), Realisation(),
+              TransferFun())

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -23,8 +23,10 @@ Parameters for an LFP cell, from the paper :footcite:t:`Prada2013`
     # κf::Function = ce -> 0.1297 * (ce / 1000)^3 - 2.51 * (ce / 1000)^1.5 +
     #                      3.329 * (ce / 1000) 
     κ::Float64 = 0.9487                                                         # Electrolyte Conductivity
-    κf::Function = ce -> (4.1253e-4 + 5.007 * ce /1e6 - 4721.2 * (ce /1e6)^2 +
-                         1.5094e6 * (ce /1e6)^3 - 1.6018e8 * (ce /1e6)^4)*1e3     # Electrolyte Conductivity Function(S/m)
+    κf::Function = ce -> (4.1253e-4 + 5.007 * (ce / 1e6) -
+                          4721.2 * (ce / 1e6)^2 +
+                          1.5094e6 * (ce / 1e6)^3 -
+                          1.6018e8 * (ce / 1e6)^4)*1e3     # Electrolyte Conductivity Function(S/m)
     Uocp::Function = (Electrode, θ) -> if Electrode == "Neg"
         Uocp = @. 1.97938 * 2.7182818284 * exp(-39.3631 * θ) + 0.2482 -
                   0.0909 * tanh(29.8538 * (θ - 0.1234)) -

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -279,6 +279,6 @@ end
     RA::Realisation
     Transfer::TransferFun
 end
-
+export Constants, Negative, Positive, Separator, Realisation, TransferFun, Params
 return Params(Constants(), Negative(), Positive(), Separator(), Realisation(),
               TransferFun())

--- a/src/Data/Prada_2013/A123.jl
+++ b/src/Data/Prada_2013/A123.jl
@@ -279,6 +279,5 @@ end
     RA::Realisation
     Transfer::TransferFun
 end
-export Constants, Negative, Positive, Separator, Realisation, TransferFun, Params
 return Params(Constants(), Negative(), Positive(), Separator(), Realisation(),
               TransferFun())

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -198,7 +198,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
              nothing
 
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
-                                  Results.y[i + 1, CsePosInd]) .>
+                                  Results.y[i + 1, CsePosInd]) >
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max :
                                  (SOCₚ .* Cell.Pos.cs_max .+

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -184,14 +184,16 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]
 
         # Concentrations & Force electrode concentration maximum
-        Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+
-                                  Results.y[i + 1, CseNegInd]) >
-                                 ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max ?
-                                 ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
-                                 (SOCₙ .* Cell.Neg.cs_max .+
-                                  Results.y[i + 1, CseNegInd])
+        # Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+
+        #                           Results.y[i + 1, CseNegInd]) >
+        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max ?
+        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
+        #                          (SOCₙ .* Cell.Neg.cs_max .+
+        #                           Results.y[i + 1, CseNegInd])
+        Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd])
+        isany(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ? Results.Cseₙ[Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max : nothing
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
-                                  Results.y[i + 1, CsePosInd]) >
+                                  Results.y[i + 1, CsePosInd]) .>
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max :
                                  (SOCₚ .* Cell.Pos.cs_max .+

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -135,6 +135,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.θₚ[i + 1] = cs_pos_avg / Cell.Pos.cs_max
         Results.Cell_SOC[i + 1] = (Results.θₙ[i + 1] - Cell.Neg.θ_0) /
                                   (Cell.Neg.θ_100 - Cell.Neg.θ_0)
+        Results.Cell_SOC[Results.Cell_SOC > 1.0] .= 1.0  # Ensure SOC is within bounds   
 
         javg_neg = Results.Iapp[i + 1] / (Cell.Neg.as * F * Cell.Neg.L * Cell.Const.CC_A)
         javg_pos = Results.Iapp[i + 1] / (Cell.Pos.as * F * Cell.Pos.L * Cell.Const.CC_A)
@@ -168,7 +169,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         ν_pos = @. Cell.Pos.L * sqrt((Cell.Pos.as * (1 / κ_eff_Pos + 1 / σ_eff_Pos)) /
                         Results.Rₜᵖ[i + 1])
 
-        # Relinearise dependent on ν, σ, κ
+        # # Relinearise dependent on ν, σ, κ
         # D = D_Linear(Cell, ν_neg, ν_pos, σ_eff_Neg, κ_eff_Neg, σ_eff_Pos, κ_eff_Pos,
         #     κ_eff_Sep)
         

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -184,14 +184,16 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]
 
         # Concentrations & Force electrode concentration maximum
-        Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+
-                                  Results.y[i + 1, CseNegInd]) >
-                                 ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max ?
-                                 ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
-                                 (SOCₙ .* Cell.Neg.cs_max .+
-                                  Results.y[i + 1, CseNegInd])
+        # Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+
+        #                           Results.y[i + 1, CseNegInd]) >
+        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max ?
+        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
+        #                          (SOCₙ .* Cell.Neg.cs_max .+
+        #                           Results.y[i + 1, CseNegInd])
+        Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd])
+        Results.Cseₙ[i + 1, Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
-                                  Results.y[i + 1, CsePosInd]) >
+                                  Results.y[i + 1, CsePosInd]) .>
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max :
                                  (SOCₚ .* Cell.Pos.cs_max .+

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -221,9 +221,12 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.jL[i + 1] = Results.y[i + 1, FluxPosInd[1]]
 
         # Neg
+        println("Time is: ", i)
+        println("Results.Cseₙ: ", Results.Cseₙ[i+1,:])
+        println("Results.Ce: ", Results.Ce[i+1,1])
+        println("Cell.Neg.cs_max - Results.Cseₙ: ", (Cell.Neg.cs_max .- Results.Cseₙ[i + 1, :]))
         j₀ⁿ = findmax([ones(size(Results.Cseₙ, 2)) * eps() (kₙ .*
-                                                            (Results.Cseₙ[i + 1,
-                :] .^
+                                                            (Results.Cseₙ[i + 1,:] .^
                                                              Cell.Neg.α) .*
                                                             (Results.Ce[i + 1, 1] .^
                                                              (1 - Cell.Neg.α))) .*

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -191,11 +191,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         #                          (SOCₙ .* Cell.Neg.cs_max .+
         #                           Results.y[i + 1, CseNegInd])
         Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd])
-<<<<<<< HEAD
-        isany(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ? Results.Cseₙ[Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max : nothing
-=======
         Results.Cseₙ[i + 1, Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max
->>>>>>> 569c857c1a1d71dbbc3a704a7dc475db145c9ac4
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
                                   Results.y[i + 1, CsePosInd]) .>
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -135,7 +135,8 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.θₚ[i + 1] = cs_pos_avg / Cell.Pos.cs_max
         Results.Cell_SOC[i + 1] = (Results.θₙ[i + 1] - Cell.Neg.θ_0) /
                                   (Cell.Neg.θ_100 - Cell.Neg.θ_0)
-        Results.Cell_SOC[Results.Cell_SOC > 1.0] .= 1.0  # Ensure SOC is within bounds   
+        Results.Cell_SOC[Results.Cell_SOC .> 1.0] .= 1.0  # Ensure SOC is within bounds   
+        Results.Cell_SOC[Results.Cell_SOC .< 0.0] .= 0.0  # Ensure SOC is within bounds
 
         javg_neg = Results.Iapp[i + 1] / (Cell.Neg.as * F * Cell.Neg.L * Cell.Const.CC_A)
         javg_pos = Results.Iapp[i + 1] / (Cell.Pos.as * F * Cell.Pos.L * Cell.Const.CC_A)

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -191,7 +191,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         #                          (SOCₙ .* Cell.Neg.cs_max .+
         #                           Results.y[i + 1, CseNegInd])
         Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd])
-        Results.Cseₙ[i + 1, Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max
+        isany(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ? Results.Cseₙ[Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max : nothing
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
                                   Results.y[i + 1, CsePosInd]) .>
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -184,6 +184,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]
 
         # Concentrations & Force electrode concentration maximum
+
         # Results.Cseₙ[i + 1, :] = any((SOCₙ .* Cell.Neg.cs_max .+
         #                           Results.y[i + 1, CseNegInd]) .> Cell.Neg.cs_max) ?
         #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
@@ -195,15 +196,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         any(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ?
              Results.Cseₙ[i+1, Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max :
              nothing
-                                 
-        # Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+
-        #                           Results.y[i + 1, CseNegInd]) >
-        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max ?
-        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
-        #                          (SOCₙ .* Cell.Neg.cs_max .+
-        #                           Results.y[i + 1, CseNegInd])
-        Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd])
-        any(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ? Results.Cseₙ[Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max : nothing
+
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
                                   Results.y[i + 1, CsePosInd]) .>
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -191,7 +191,7 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         #                          (SOCₙ .* Cell.Neg.cs_max .+
         #                           Results.y[i + 1, CseNegInd])
         Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd])
-        isany(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ? Results.Cseₙ[Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max : nothing
+        any(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ? Results.Cseₙ[Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max : nothing
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
                                   Results.y[i + 1, CsePosInd]) .>
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -184,12 +184,18 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]
 
         # Concentrations & Force electrode concentration maximum
-        Results.Cseₙ[i + 1, :] = (SOCₙ .* Cell.Neg.cs_max .+
-                                  Results.y[i + 1, CseNegInd]) >
-                                 ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max ?
-                                 ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
-                                 (SOCₙ .* Cell.Neg.cs_max .+
-                                  Results.y[i + 1, CseNegInd])
+        # Results.Cseₙ[i + 1, :] = any((SOCₙ .* Cell.Neg.cs_max .+
+        #                           Results.y[i + 1, CseNegInd]) .> Cell.Neg.cs_max) ?
+        #                          ones(size(Results.Cseₙ, 2)) * Cell.Neg.cs_max :
+        #                          (SOCₙ .* Cell.Neg.cs_max .+
+        #                           Results.y[i + 1, CseNegInd])
+        # Define the concentration of the negative electrode
+        Results.Cseₙ[i + 1, :] = SOCₙ .* Cell.Neg.cs_max .+ Results.y[i + 1, CseNegInd]
+        # Check if any of the concentrations is greater than the maximum concentration
+        any(Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max) ?
+             Results.Cseₙ[i+1, Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max :
+             nothing
+                                 
         Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
                                   Results.y[i + 1, CsePosInd]) >
                                  ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -221,10 +221,16 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         Results.jL[i + 1] = Results.y[i + 1, FluxPosInd[1]]
 
         # Neg
-        println("Time is: ", i)
-        println("Results.Cseₙ: ", Results.Cseₙ[i+1,:])
-        println("Results.Ce: ", Results.Ce[i+1,1])
-        println("Cell.Neg.cs_max - Results.Cseₙ: ", (Cell.Neg.cs_max .- Results.Cseₙ[i + 1, :]))
+        # check if any of the concentrations is negative
+        if any(Results.Cseₙ[i + 1, :] .< 0.0) || Results.Ce[i + 1, 1] .< 0.0 || any((Cell.Neg.cs_max .- Results.Cseₙ[i + 1, :]) .< 0.0)
+            println("Negative Concentration in Negative Electrode")
+            println("Time is: ", i)
+            println("Results.Cseₙ: ", Results.Cseₙ[i+1,:])
+            println("Results.Ce: ", Results.Ce[i+1,1])
+            println("Cell.Neg.cs_max - Results.Cseₙ: ", (Cell.Neg.cs_max .- Results.Cseₙ[i + 1, :]))
+            break
+        end
+        
         j₀ⁿ = findmax([ones(size(Results.Cseₙ, 2)) * eps() (kₙ .*
                                                             (Results.Cseₙ[i + 1,:] .^
                                                              Cell.Neg.α) .*

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -169,14 +169,15 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
                         Results.Rₜᵖ[i + 1])
 
         # Relinearise dependent on ν, σ, κ
-        D = D_Linear(Cell, ν_neg, ν_pos, σ_eff_Neg, κ_eff_Neg, σ_eff_Pos, κ_eff_Pos,
-            κ_eff_Sep)
-        println("D: ", D)
+        # D = D_Linear(Cell, ν_neg, ν_pos, σ_eff_Neg, κ_eff_Neg, σ_eff_Pos, κ_eff_Pos,
+        #     κ_eff_Sep)
+        
         # Interpolate C & D Matrices
         C = interp(C₀, SList, Results.Cell_SOC[i + 1])
-        # D = interp(D₀,SList,Results.Cell_SOC[i+1])
+        D = interp(D₀,SList,Results.Cell_SOC[i+1])
         println("C: ", C)
-
+        println("D: ", D)
+        
         # SS Output
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]
 

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -175,8 +175,8 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         # Interpolate C & D Matrices
         C = interp(C₀, SList, Results.Cell_SOC[i + 1])
         D = interp(D₀,SList,Results.Cell_SOC[i+1])
-        println("C: ", C)
-        println("D: ", D)
+        # println("C: ", C)
+        # println("D: ", D)
         
         # SS Output
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -171,10 +171,11 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         # Relinearise dependent on ν, σ, κ
         D = D_Linear(Cell, ν_neg, ν_pos, σ_eff_Neg, κ_eff_Neg, σ_eff_Pos, κ_eff_Pos,
             κ_eff_Sep)
-
+        println("D: ", D)
         # Interpolate C & D Matrices
         C = interp(C₀, SList, Results.Cell_SOC[i + 1])
         # D = interp(D₀,SList,Results.Cell_SOC[i+1])
+        println("C: ", C)
 
         # SS Output
         Results.y[i + 1, :] = C * Results.x[i + 1, :] + D * Results.Iapp[i + 1]

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -197,12 +197,17 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
              Results.Cseₙ[i+1, Results.Cseₙ[i + 1, :] .> Cell.Neg.cs_max] .= Cell.Neg.cs_max :
              nothing
 
-        Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
-                                  Results.y[i + 1, CsePosInd]) >
-                                 ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?
-                                 ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max :
-                                 (SOCₚ .* Cell.Pos.cs_max .+
-                                  Results.y[i + 1, CsePosInd])
+        # Results.Cseₚ[i + 1, :] = (SOCₚ .* Cell.Pos.cs_max .+
+        #                           Results.y[i + 1, CsePosInd]) >
+        #                          ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max ?
+        #                          ones(size(Results.Cseₚ, 2)) * Cell.Pos.cs_max :
+        #                          (SOCₚ .* Cell.Pos.cs_max .+
+        #                           Results.y[i + 1, CsePosInd])
+        Results.Cseₚ[i + 1, :] = SOCₚ .* Cell.Pos.cs_max .+ Results.y[i + 1, CsePosInd]
+        any(Results.Cseₚ[i + 1, :] .> Cell.Pos.cs_max) ?
+             Results.Cseₚ[i+1, Results.Cseₚ[i + 1, :] .> Cell.Pos.cs_max] .= Cell.Pos.cs_max :
+             nothing
+
         Results.Ce[i + 1, :] = @. Cell.Const.ce0 + Results.y[i + 1, CeInd]
 
         # Potentials

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -207,8 +207,8 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         any(Results.Cseₚ[i + 1, :] .> Cell.Pos.cs_max) ?
              Results.Cseₚ[i+1, Results.Cseₚ[i + 1, :] .> Cell.Pos.cs_max] .= Cell.Pos.cs_max :
              nothing
-        any(Results.Cseₚ[i + 1, :] .< 0.0) ?
-             Results.Cseₚ[i+1, Results.Cseₚ[i + 1, :] .< 0.0] .= 0.0 :
+        any(Results.Cseₚ[i + 1, :] .< 1.0) ?
+             Results.Cseₚ[i+1, Results.Cseₚ[i + 1, :] .< 1.0] .= 1.0 :
              nothing
 
         Results.Ce[i + 1, :] = @. Cell.Const.ce0 + Results.y[i + 1, CeInd]

--- a/src/Functions/Simulate.jl
+++ b/src/Functions/Simulate.jl
@@ -207,6 +207,9 @@ function Simulate(Cell, Input, Def, Tk, SList, SOC, A₀, B₀, C₀, D₀, t)
         any(Results.Cseₚ[i + 1, :] .> Cell.Pos.cs_max) ?
              Results.Cseₚ[i+1, Results.Cseₚ[i + 1, :] .> Cell.Pos.cs_max] .= Cell.Pos.cs_max :
              nothing
+        any(Results.Cseₚ[i + 1, :] .< 0.0) ?
+             Results.Cseₚ[i+1, Results.Cseₚ[i + 1, :] .< 0.0] .= 0.0 :
+             nothing
 
         Results.Ce[i + 1, :] = @. Cell.Const.ce0 + Results.y[i + 1, CeInd]
 

--- a/src/LiiBRA.jl
+++ b/src/LiiBRA.jl
@@ -151,6 +151,9 @@ function Construct(CellType::String)
     elseif CellType == "LG M50"
         CellType = string("LG_M50.jl")
         return include(joinpath(dirname(pathof(LiiBRA)), "Data/Chen_2020", CellType))
+    elseif CellType == "A123"
+        CellType = string("A123.jl")
+        return include(joinpath(dirname(pathof(LiiBRA)), "Data/Prada_2013", CellType))
     end
 end
 

--- a/src/LiiBRA.jl
+++ b/src/LiiBRA.jl
@@ -84,7 +84,9 @@ function HPPC(Cell, Ŝ::Array, SOC::Float64, λ::Float64, ϕ::Float64, A::Tuple
     Input = [zero(i); ones(10 * i) * λ; zeros(40 * i); ones(10 * i) * ϕ; zeros(40 * i)]
     Tk = ones(size(Input)) * Cell.Const.T #Cell Temperature
     t = 0:(1.0 / i):((length(Input) - 1) / i)
-
+    println(typeof(A))
+    println(typeof(SOC))
+    println(typeof(Ŝ))
     # Simulate Model
     return Simulate(Cell, Input, "Current", Tk, Ŝ, SOC, A, B, C, D, t)
 end

--- a/src/LiiBRA.jl
+++ b/src/LiiBRA.jl
@@ -2,10 +2,10 @@ module LiiBRA
 
 using UnitSystems, Parameters, LinearAlgebra, FFTW
 using TSVD, Roots, Statistics, Interpolations, JLD2
-export C_e, Flux, C_se, Phi_s, Phi_e, Phi_se, CIDRA
-export flatten_, R, F, Simulate, D_Linear, Construct
-export tuple_len, interp, Spatial!, Realise, HPPC, fh!
-export mag!, findnearest, CC, WLTP
+# export C_e, Flux, C_se, Phi_s, Phi_e, Phi_se, CIDRA
+# export flatten_, R, F, Simulate, D_Linear, Construct
+# export tuple_len, interp, Spatial!, Realise, HPPC, fh!
+# export mag!, findnearest, CC, WLTP
 
 include("Functions/C_e.jl")
 include("Functions/C_se.jl")
@@ -337,6 +337,13 @@ function D_Linear(Cell, ν_neg, ν_pos, σ_eff_Neg, κ_eff_Neg, σ_eff_Pos, κ_e
         D = [D; Dt]
     end
     return D
+end
+# automatically export all functions and types
+# export all
+for n in names(@__MODULE__; all=true)
+    if Base.isidentifier(n) && n ∉ (Symbol(@__MODULE__), :eval, :include)
+        @eval export $n
+    end
 end
 
 end # module

--- a/src/LiiBRA.jl
+++ b/src/LiiBRA.jl
@@ -15,10 +15,6 @@ include("Functions/Phi_e.jl")
 include("Functions/Phi_se.jl")
 include("Functions/Simulate.jl")
 include("Methods/CIDRA.jl")
-include("Data/Chen_2020/LG_M50.jl")
-include("Data/Doyle_94/Doyle_94.jl")
-include("Data/Prada_2013/A123.jl")
-include("Data/Xu_2019/Xu2019.jl")
 
 const F, R = faraday(Metric), universal(SI2019) #Faraday Constant / Universal Gas Constant 
 findnearest(A, x) = argmin(abs.(A .- x)) # Find Nearest for SOC initialisation

--- a/src/LiiBRA.jl
+++ b/src/LiiBRA.jl
@@ -15,6 +15,10 @@ include("Functions/Phi_e.jl")
 include("Functions/Phi_se.jl")
 include("Functions/Simulate.jl")
 include("Methods/CIDRA.jl")
+include("Data/Chen_2020/LG_M50.jl")
+include("Data/Doyle_94/Doyle_94.jl")
+include("Data/Prada_2013/A123.jl")
+include("Data/Xu_2019/Xu2019.jl")
 
 const F, R = faraday(Metric), universal(SI2019) #Faraday Constant / Universal Gas Constant 
 findnearest(A, x) = argmin(abs.(A .- x)) # Find Nearest for SOC initialisation


### PR DESCRIPTION
All 3 current parameter sets were for NMC cells.
This pull request intends to add the LFP A123 parameter set from [Prada (2013)](https://iopscience.iop.org/article/10.1149/2.053304jes/meta).
The parameter set is ok but it crashes with the current implementation of `Simulate.jl` and `D_linear()`